### PR TITLE
Support API >= 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ support [IPv6] (yet?).
 
 ## Requirements
 
-The Android application requires at least API 21 (Android 5.0).
+The Android application requires at least API 14 (Android 4.0).
 
 _Java 8_ is required on your computer. On Debian-based distros, install the
 package `openjdk-8-jre`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         archivesBaseName = "gnirehtet" // change apk name
         applicationId "com.genymobile.gnirehtet"
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/genymobile/gnirehtet/Forwarder.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/Forwarder.java
@@ -101,6 +101,8 @@ public class Forwarder {
             if (r > 0) {
                 // blocking send
                 tunnel.send(buffer, r);
+            } else {
+                Log.w(TAG, "Empty read");
             }
         }
         Log.d(TAG, "Device to tunnel forwarding stopped");
@@ -125,6 +127,8 @@ public class Forwarder {
                 }
                 // blocking write
                 packetOutputStream.write(buffer, 0, w);
+            } else {
+                Log.w(TAG, "Empty write");
             }
         }
         Log.d(TAG, "Tunnel to device forwarding stopped");

--- a/app/src/main/java/com/genymobile/gnirehtet/IoUtils.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/IoUtils.java
@@ -1,0 +1,39 @@
+package com.genymobile.gnirehtet;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class IoUtils {
+
+    private IoUtils() {
+        // not instantiable
+    }
+
+    /**
+     * Set {@code fd} to be blocking or non-blocking, according to the state of {@code blocking}.
+     *
+     * @param fd       the file descriptor
+     * @param blocking the target blocking mode
+     * @throws IOException if an I/O problem occurs
+     */
+    public static void setBlocking(FileDescriptor fd, boolean blocking) throws IOException {
+        // calls libcore.io.IoUtils.setBlocking(FileDescriptor, boolean) using reflection
+        // <https://android.googlesource.com/platform/libcore/+/30c669166d86d0bd133edfb67909665fb41d29b6/luni/src/main/java/libcore/io/IoUtils.java#89>
+        try {
+            Class<?> cls = Class.forName("libcore.io.IoUtils");
+            Method setBlocking = cls.getDeclaredMethod("setBlocking", FileDescriptor.class, boolean.class);
+            setBlocking.invoke(null, fd, blocking);
+            // cannot multi-catch on API < 19
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException("Cannot call libcore.io.IoUtils.setBlocking()", e);
+        } catch (NoSuchMethodException e) {
+            throw new UnsupportedOperationException("Cannot call libcore.io.IoUtils.setBlocking()", e);
+        } catch (IllegalAccessException e) {
+            throw new UnsupportedOperationException("Cannot call libcore.io.IoUtils.setBlocking()", e);
+        } catch (InvocationTargetException e) {
+            throw new UnsupportedOperationException("Cannot call libcore.io.IoUtils.setBlocking()", e);
+        }
+    }
+}

--- a/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
@@ -38,7 +38,7 @@ public class VpnConfiguration implements Parcelable {
                 dnsServers[i] = InetAddress.getByAddress(source.createByteArray());
             }
         } catch (UnknownHostException e) {
-            throw new AssertionError("Invalid address", e);
+            throw new RuntimeException("Invalid address", e);
         }
     }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Material.Light.DarkActionBar">
+    <style name="AppTheme">
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
The minSdkVersion was set to 21 due to the call to
VpnService.Builder.setBlocking(true).

On API < 21, we can call the internal method
libcore.io.IoUtils.setBlocking() using reflection:
<https://android.googlesource.com/platform/libcore/+/30c669166d86d0bd133edfb67909665fb41d29b6/luni/src/main/java/libcore/io/IoUtils.java#89>

Therefore, use it as a fallback and set the minSdkVersion to 14, in
order to support devices from Android 4.0.

Related to <https://github.com/Genymobile/gnirehtet/issues/2>.